### PR TITLE
Removed wrong license header

### DIFF
--- a/fop_vouchers.php
+++ b/fop_vouchers.php
@@ -1,28 +1,4 @@
 <?php
-/**
- * 2007-2020 PrestaShop
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2020 PrestaShop SA
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
- */
 
 if (!defined('_PS_VERSION_')) {
     exit;


### PR DESCRIPTION
I'm not sure we're allowed to use the Licence headers of PrestaShop.

I used to do it here cause I was previously an employee of this company but I think we should use our own licence headers.

(And maybe @ttoine can help us on that specific subject ?)